### PR TITLE
Fix a crash in ibus-table caused by "src/ibusenginesimple: Do not upd…

### DIFF
--- a/src/ibusenginesimple.c
+++ b/src/ibusenginesimple.c
@@ -387,7 +387,7 @@ ibus_engine_simple_update_preedit_text (IBusEngineSimple *simple)
          * ibus_engine_hide_preedit_text() here could cause a reset of
          * the cursor position in ibus-daemon.
          */
-        if (strlen (priv->updated_preedit->text)) {
+        if (priv->updated_preedit && strlen (priv->updated_preedit->text)) {
             ibus_engine_hide_preedit_text ((IBusEngine *)simple);
             g_object_unref (priv->updated_preedit);
             priv->updated_preedit = ibus_text_new_from_string ("");


### PR DESCRIPTION
…ate zero length preedit text"

This causes a crash when typing for example Backspace or Down with an empty preedit in ibus-table:

commit 7bfd2ad82014bdaffb39e59c166d1d7c507e4ee7 (HEAD -> simple-hide-0-preedit, fujiwarat/simple-hide-0-preedit)
Author: fujiwarat <takao.fujiwara1@gmail.com>
Date:   Thu Sep 14 17:44:26 2023 +0900

    src/ibusenginesimple: Do not update zero length preedit text

    Several engines can inherit IBusEngieSimple for the compose key support
    likes Anthy, Hangul, M17n and it could have the duplicated preedit text
    between the engine and the parent IBusEngineSimple and it could update
    the preedit text mutually by mistake.

    Then the preedit text should not be hidden for zero length at least.
    This update might not be enough but hope to fix the cursor position
    reset with hiding the preedit text against the reported issue with
    `m17n:sa:itrans` engine.

    BUG=https://github.com/ibus/ibus/issues/2536