### PR TITLE
client/x11: wip: Call setlocale()

### DIFF
--- a/client/x11/main.c
+++ b/client/x11/main.c
@@ -1368,6 +1368,8 @@ main (int argc, char **argv)
     gdk_set_allowed_backends ("x11");
 #endif
 
+    /* gdk_init() does not call setlocale() */
+    setlocale (LC_ALL, "");
     gdk_init (&argc, &argv);
     XSetErrorHandler (_xerror_handler);
     XSetIOErrorHandler (_xerror_io_handler);


### PR DESCRIPTION
To enhance #2547, ibus-x11 replaces gtk_init() with gdk_init(). Seems gdk_init() does not call setlocale() internally and ibus-x11 causes some encoding errors when the multi-byte chars are converted to the text property of compound text.

BUG=https://github.com/ibus/ibus/issues/2896
Fixes: https://github.com/ibus/ibus/commit/b185b21